### PR TITLE
fix: 🧩 修复echarts菜单下面违反钩子规则的写法

### DIFF
--- a/src/hooks/useEcharts.ts
+++ b/src/hooks/useEcharts.ts
@@ -1,30 +1,30 @@
 import * as echarts from "echarts";
+import { useCallback, useEffect, useRef } from "react";
 /**
  * @description 使用Echarts(只是为了添加图表响应式)
  * @param {Element} myChart Echarts实例(必传)
  * @param {Object} options 绘制Echarts的参数(必传)
- * @return void
+ * @return deleteEvent 待改善(后期重新写)
  * */
-const useEcharts = (myChart: echarts.ECharts, options: echarts.EChartsCoreOption) => {
-	if (options && typeof options === "object") {
-		myChart.setOption(options);
-	}
+export const useEcharts = (myChart: echarts.ECharts, options: echarts.EChartsCoreOption) => {
+	const ref = useRef<echarts.ECharts>();
 
-	const echartsResize = () => {
-		myChart && myChart.resize();
-	};
+	const resize = useCallback(() => {
+		if (ref.current) {
+			ref.current.resize();
+		}
+	}, []);
 
-	const addEvent = () => {
-		window.addEventListener("resize", echartsResize, false);
-	};
+	useEffect(() => {
+		// ref.current = echarts.init();
+		// if (options && typeof options === "object") {
+		// 	ref.current.setOption(options);
+		// }
+		// window.addEventListener("resize", resize);
+		// return () => {
+		// 	window.removeEventListener("resize", resize);
+		// };
+	}, [options, myChart]);
 
-	addEvent();
-
-	const deleteEvent = () => {
-		window.removeEventListener("resize", echartsResize);
-	};
-
-	return { deleteEvent };
+	return { echartsInst: ref.current };
 };
-
-export default useEcharts;

--- a/src/views/echarts/columnChart/index.tsx
+++ b/src/views/echarts/columnChart/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
-import useEcharts from "@/hooks/useEcharts";
 
 const ColumnChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let option: echarts.EChartsOption = {
 		tooltip: {
 			trigger: "axis",
@@ -129,13 +129,23 @@ const ColumnChart = () => {
 		]
 	};
 
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		useEcharts(myChart, option);
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
 
 	return <div ref={echartsRef} className="content-box"></div>;
 };

--- a/src/views/echarts/lineChart/index.tsx
+++ b/src/views/echarts/lineChart/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
-import useEcharts from "@/hooks/useEcharts";
 
 const LineChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let option: echarts.EChartsOption = {
 		title: {
 			text: "Stacked Area Chart",
@@ -113,13 +113,23 @@ const LineChart = () => {
 		]
 	};
 
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		useEcharts(myChart, option);
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
 
 	return <div ref={echartsRef} className="content-box"></div>;
 };

--- a/src/views/echarts/nestedChart/index.tsx
+++ b/src/views/echarts/nestedChart/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
-import useEcharts from "@/hooks/useEcharts";
 
 const NestedChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let option: echarts.EChartsOption = {
 		tooltip: {
 			trigger: "item",
@@ -86,13 +86,24 @@ const NestedChart = () => {
 			}
 		]
 	};
+
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		useEcharts(myChart, option);
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
 
 	return <div ref={echartsRef} className="content-box"></div>;
 };

--- a/src/views/echarts/pieChart/index.tsx
+++ b/src/views/echarts/pieChart/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
-import useEcharts from "@/hooks/useEcharts";
 
 const PieChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let option: echarts.EChartsOption = {
 		tooltip: {
 			trigger: "item",
@@ -58,13 +58,23 @@ const PieChart = () => {
 		]
 	};
 
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		useEcharts(myChart, option);
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
 
 	return <div ref={echartsRef} className="content-box"></div>;
 };

--- a/src/views/echarts/radarChart/index.tsx
+++ b/src/views/echarts/radarChart/index.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
-import useEcharts from "@/hooks/useEcharts";
 
 const RadarChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let option: echarts.EChartsOption = {
 		title: {
 			text: "Basic Radar Chart",
@@ -46,13 +46,23 @@ const RadarChart = () => {
 		]
 	};
 
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		useEcharts(myChart, option);
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
 
 	return <div ref={echartsRef} className="content-box"></div>;
 };

--- a/src/views/echarts/waterChart/index.tsx
+++ b/src/views/echarts/waterChart/index.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useRef } from "react";
 import * as echarts from "echarts";
 import "echarts-liquidfill";
-import useEcharts from "@/hooks/useEcharts";
 import "./index.less";
 
 const WaterChart = () => {
 	const echartsRef = useRef<HTMLDivElement>(null);
+	let myChart: echarts.EChartsType;
 	let value = 0.5;
 	let data = [value, value, value];
 	let option: echarts.EChartsCoreOption = {
@@ -292,17 +292,29 @@ const WaterChart = () => {
 		]
 	};
 
+	const setEcharts = () => {
+		option && myChart.setOption(option);
+	};
+
 	useEffect(() => {
-		// 创建一个echarts实例，返回echarts实例。不能在单个容器中创建多个echarts实例
-		const myChart: echarts.EChartsType = echarts.init(echartsRef.current as HTMLDivElement);
-		// 设置图表实例的配置项和数据
-		useEcharts(myChart, option);
-		// 组件卸载
+		myChart = echarts.init(echartsRef.current as HTMLDivElement);
+		const echartsResize = () => {
+			myChart && myChart.resize();
+		};
+		window.addEventListener("resize", echartsResize, false);
+
+		setEcharts();
 		return () => {
-			// myChart.dispose() 销毁实例。实例销毁后无法再被使用
+			window.removeEventListener("resize", echartsResize);
 			myChart && myChart.dispose();
 		};
-	}, []);
+	});
+
+	// 只判断数据的变化来动态setEcharts
+	useEffect(() => {
+		setEcharts();
+	}, [value]);
+
 	return <div ref={echartsRef} className="content-box"></div>;
 };
 


### PR DESCRIPTION
写的自定义useEcharts违反官方钩子规则，重新修改了渲染写法