### PR TITLE
perf: Axios CancelToken -> AbortController

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"commit": "git pull && git add -A && git-cz && git push"
 	},
 	"dependencies": {
+		"@ant-design/icons": "^5.0.1",
 		"antd": "^4.22.2",
 		"axios": "^0.27.2",
 		"driver.js": "^0.9.8",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -74,6 +74,7 @@ class RequestHttp {
 			},
 			async (error: AxiosError) => {
 				const { response } = error;
+				// * 即使
 				NProgress.done();
 				tryHideFullScreenLoading();
 				// 请求超时单独判断，请求超时没有 response


### PR DESCRIPTION
https://axios-http.com/zh/docs/cancellation

从 v0.22.0 开始，Axios 支持以 fetch API 方式—— [AbortController](https://developer.mozilla.org/en-US/docs/Web/API/AbortController) 取消请求

**CancelToken** API 从 v0.22.0 开始已被弃用，不应在新项目中使用