### PR TITLE
fix:  修复跳转404页面之后，无法通过浏览器back后退至历史页面的问题

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
 	"stylelint.enable": true,
 	// 开启stylelint自动修复
 	"editor.codeActionsOnSave": {
-		"source.fixAll.stylelint": true
+		"source.fixAll.stylelint": "explicit"
 	},
 	// 配置stylelint检查的文件类型范围
 	"stylelint.validate": ["css", "less", "postcss", "scss", "sass"],
@@ -45,5 +45,6 @@
 		"truetype",
 		"zhongyingwen",
 		"zhuti"
-	]
+	],
+	"i18n-ally.localesPaths": ["src/language"]
 }

--- a/src/routers/index.tsx
+++ b/src/routers/index.tsx
@@ -1,6 +1,7 @@
 import { Navigate, useRoutes } from "react-router-dom";
 import { RouteObject } from "@/routers/interface";
 import Login from "@/views/login/index";
+import NoFound from "@/components/ErrorMessage/404";
 
 // * 导入所有router
 const metaRouters = import.meta.globEager("./modules/*.tsx");
@@ -30,7 +31,12 @@ export const rootRouter: RouteObject[] = [
 	...routerArray,
 	{
 		path: "*",
-		element: <Navigate to="/404" />
+		element: <NoFound />,
+		meta: {
+			requiresAuth: false,
+			title: "404页面",
+			key: "404"
+		}
 	}
 ];
 


### PR DESCRIPTION
作者在跳转404时使用了Navigate组件，此组件会导致页面重定向，从而丢失历史页面，使得一旦进入404页面，就无法通过回退按钮返回上一个页面，只能点击”back home“按钮进入主页
此提交主要修改了routers/index.tsx，将Navigate跳转的方式替换为同登录一样的跳转方式